### PR TITLE
feature: Add arm64 as target platform

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       # build-args: |
       #   foo: bar
       # Define the target platforms of the docker build (default "linux/amd64,linux/arm64/v8")
-      build-platforms: "linux/amd64"
+      # build-platforms: "linux/amd64,linux/arm64/v8"
       # If your actions generate an artifact in a previous build step, you can tell this workflow to download it
       # artifact-name: '' # the default '' doesn't try to download an artifact
     # This passes the secrets from calling workflow to the called workflow


### PR DESCRIPTION
By building the Bitwarden CLI ourselves, we can offer arm64 builds again.